### PR TITLE
feature: allows null to be added as a value in the JsonBuilder

### DIFF
--- a/src/Builder/AbstractJsonBuilder.php
+++ b/src/Builder/AbstractJsonBuilder.php
@@ -34,10 +34,15 @@ abstract class AbstractJsonBuilder
         return $this->addProperty($prop,  $value);
     }
 
+    public function addNullProperty(string $prop): self
+    {
+        return $this->addProperty($prop);
+    }
+
     /**
      * @throws JsonRuntimeException
      */
-    protected function addProperty(string $prop, $value): self
+    protected function addProperty(string $prop, $value = null): self
     {
         $this->validatePropertyName($prop) ?? throw new JsonRuntimeException('Unable to add property $prop');
         $this->{$prop} = $value;

--- a/tests/Builder/AbstractJsonBuilderTest.php
+++ b/tests/Builder/AbstractJsonBuilderTest.php
@@ -105,6 +105,26 @@ JSON;
         );
     }
 
+    public function testAddNullProperty(): void
+    {
+        $sut = $this->createBuilder();
+
+        $expected = <<<JSON
+{
+    "foo": 12345.678,
+    "bar": null
+}
+JSON;
+
+        $sut->addNumericProperty("foo", 12345.678);
+        $sut->addNullProperty("bar");
+
+        self::assertEquals(
+            $expected,
+            ((string) $sut)
+        );
+    }
+
     private function createBuilder(): AbstractJsonBuilder
     {
         return new class extends AbstractJsonBuilder {};


### PR DESCRIPTION

```php
echo Json::createJsonBuilder()
        ->addNumericProperty('id', 11)
        ->addNullProperty('thisIsNull')
;

```

Will display

```json
{
   "id": 11,
   "thisIsNull": null
}
```